### PR TITLE
Move event callbacks to methods

### DIFF
--- a/src/FocusTrap.vue
+++ b/src/FocusTrap.vue
@@ -65,6 +65,12 @@
           clickOutsideDeactivates: this.deactivateOnOutsideClick,
           returnFocusOnDeactivate: this.returnFocusOnDeactivate
         }))
+      },
+      onActivate () {
+        this.$emit('activated')
+      },
+      onDeactivate () {
+        this.$emit('deactivated')
       }
     },
     watch: {
@@ -81,12 +87,6 @@
         } else if (!oldVal && val) {
           this.focusTrap.pause()
         }
-      },
-      onActivate () {
-        this.$emit('activated')
-      },
-      onDeactivate () {
-        this.$emit('deactivated')
       }
     }
   }


### PR DESCRIPTION
Move event callbacks to methods as they don't get passed to `createFocusTrap` as watchers.